### PR TITLE
Add symfony 4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
   - 5.5
   - 5.6
   - 7.0
-  - hhvm
 
 install:
   - travis_retry composer install --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
 
     "require": {
         "php": ">=5.5",
-        "symfony/process": "^2.5"
+        "symfony/process": "^2.5 | ^4.0"
     },
 
     "require-dev": {


### PR DESCRIPTION
Before:

```
[burhan@enceladus supervisor (symfony4-support)] {0} $ composer require symfony/console=^4.0
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Conclusion: remove symfony/process v2.8.46
    - Conclusion: don't install symfony/process v2.8.46
    - symfony/console v4.0.0 conflicts with symfony/process[v2.8.46].
    - symfony/console v4.0.1 conflicts with symfony/process[v2.8.46].
    - symfony/console v4.0.10 conflicts with symfony/process[v2.8.46].
    - symfony/console v4.0.11 conflicts with symfony/process[v2.8.46].
    - symfony/console v4.0.12 conflicts with symfony/process[v2.8.46].
    - symfony/console v4.0.13 conflicts with symfony/process[v2.8.46].
    - symfony/console v4.0.14 conflicts with symfony/process[v2.8.46].
    - symfony/console v4.0.2 conflicts with symfony/process[v2.8.46].
    - symfony/console v4.0.3 conflicts with symfony/process[v2.8.46].
    - symfony/console v4.0.4 conflicts with symfony/process[v2.8.46].
    - symfony/console v4.0.5 conflicts with symfony/process[v2.8.46].
    - symfony/console v4.0.6 conflicts with symfony/process[v2.8.46].
    - symfony/console v4.0.7 conflicts with symfony/process[v2.8.46].
    - symfony/console v4.0.8 conflicts with symfony/process[v2.8.46].
    - symfony/console v4.0.9 conflicts with symfony/process[v2.8.46].
    - symfony/console v4.1.0 conflicts with symfony/process[v2.8.46].
    - symfony/console v4.1.1 conflicts with symfony/process[v2.8.46].
    - symfony/console v4.1.2 conflicts with symfony/process[v2.8.46].
    - symfony/console v4.1.3 conflicts with symfony/process[v2.8.46].
    - symfony/console v4.1.4 conflicts with symfony/process[v2.8.46].
    - symfony/console v4.1.5 conflicts with symfony/process[v2.8.46].
    - symfony/console v4.1.6 conflicts with symfony/process[v2.8.46].
    - Installation request for symfony/process (locked at v2.8.46, required as ^2.5) -> satisfiable by symfony/process[v2.8.46].
    - Installation request for symfony/console ^4.0 -> satisfiable by symfony/console[v4.0.0, v4.0.1, v4.0.10, v4.0.11, v4.0.12, v4.0.13, v4.0.14, v4.0.2, v4.0.3, v4.0.4, v4.0.5, v4.0.6, v4.0.7, v4.0.8, v4.0.9, v4.1.0, v4.1.1, v4.1.2, v4.1.3, v4.1.4, v4.1.5, v4.1.6].


Installation failed, reverting ./composer.json to its original content.
```

After: Installs fine.

Fixes #5 