### PR TITLE
Remove 'withNoArgs()' from tests

### DIFF
--- a/tests/unit/Exception/TerminatedProcessExceptionTest.php
+++ b/tests/unit/Exception/TerminatedProcessExceptionTest.php
@@ -18,11 +18,11 @@ class TerminatedProcessExceptionTest extends TestCase
     public function testInterface()
     {
 
-        $this->process->shouldReceive('getCommandLine')->once()->withNoArgs()->andReturn('foo');
-        $this->process->shouldReceive('getExitCode')->once()->withNoArgs()->andReturn(1);
-        $this->process->shouldReceive('getExitCodeText')->once()->withNoArgs()->andReturn('bar');
-        $this->process->shouldReceive('getOutput')->once()->withNoArgs()->andReturn('baz');
-        $this->process->shouldReceive('getErrorOutput')->once()->withNoArgs()->andReturn('bam');
+        $this->process->shouldReceive('getCommandLine')->once()->andReturn('foo');
+        $this->process->shouldReceive('getExitCode')->once()->andReturn(1);
+        $this->process->shouldReceive('getExitCodeText')->once()->andReturn('bar');
+        $this->process->shouldReceive('getOutput')->once()->andReturn('baz');
+        $this->process->shouldReceive('getErrorOutput')->once()->andReturn('bam');
 
         $exception = new TerminatedProcessException($this->process);
 
@@ -32,11 +32,11 @@ class TerminatedProcessExceptionTest extends TestCase
 
     public function testGetProcess()
     {
-        $this->process->shouldReceive('getCommandLine')->once()->withNoArgs()->andReturn('foo');
-        $this->process->shouldReceive('getExitCode')->once()->withNoArgs()->andReturn(1);
-        $this->process->shouldReceive('getExitCodeText')->once()->withNoArgs()->andReturn('bar');
-        $this->process->shouldReceive('getOutput')->once()->withNoArgs()->andReturn('baz');
-        $this->process->shouldReceive('getErrorOutput')->once()->withNoArgs()->andReturn('bam');
+        $this->process->shouldReceive('getCommandLine')->once()->andReturn('foo');
+        $this->process->shouldReceive('getExitCode')->once()->andReturn(1);
+        $this->process->shouldReceive('getExitCodeText')->once()->andReturn('bar');
+        $this->process->shouldReceive('getOutput')->once()->andReturn('baz');
+        $this->process->shouldReceive('getErrorOutput')->once()->andReturn('bam');
 
         $exception = new TerminatedProcessException($this->process);
 

--- a/tests/unit/Handler/RetryHandlerTest.php
+++ b/tests/unit/Handler/RetryHandlerTest.php
@@ -37,14 +37,14 @@ class RetryHandlerTest extends TestCase
 
     public function testHandleFailFirstTime()
     {
-        $this->sup->shouldReceive('restart')->once()->withNoArgs();
+        $this->sup->shouldReceive('restart')->once();
 
         $this->assertTrue($this->handler->handleFail(0, $this->sup));
     }
 
     public function testHandleFailMaxTime()
     {
-        $this->sup->shouldReceive('restart')->once()->withNoArgs();
+        $this->sup->shouldReceive('restart')->once();
 
         $this->assertTrue($this->handler->handleFail($this->max, $this->sup));
     }

--- a/tests/unit/ProcessSupervisorTest.php
+++ b/tests/unit/ProcessSupervisorTest.php
@@ -33,7 +33,7 @@ class ProcessSupervisorTest extends TestCase
 
     public function testUnterminatedPing()
     {
-        $this->process->shouldReceive('isTerminated')->once()->withNoArgs()->andReturn(false);
+        $this->process->shouldReceive('isTerminated')->once()->andReturn(false);
 
         $this->assertTrue($this->sup->ping());
     }
@@ -43,10 +43,10 @@ class ProcessSupervisorTest extends TestCase
         $err = 'foo';
         $out = 'bar';
 
-        $this->process->shouldReceive('isTerminated')->once()->withNoArgs()->andReturn(true);
-        $this->process->shouldReceive('isSuccessful')->once()->withNoArgs()->andReturn(true);
-        $this->process->shouldReceive('getErrorOutput')->once()->withNoArgs()->andReturn($err);
-        $this->process->shouldReceive('getOutput')->once()->withNoArgs()->andReturn($out);
+        $this->process->shouldReceive('isTerminated')->once()->andReturn(true);
+        $this->process->shouldReceive('isSuccessful')->once()->andReturn(true);
+        $this->process->shouldReceive('getErrorOutput')->once()->andReturn($err);
+        $this->process->shouldReceive('getOutput')->once()->andReturn($out);
         $this->handler->shouldReceive('handlePass')->once()->with(0, $this->sup);
 
         $this->assertFalse($this->sup->ping());
@@ -59,13 +59,13 @@ class ProcessSupervisorTest extends TestCase
         $err = 'foo';
         $out = 'bar';
 
-        $this->process->shouldReceive('isTerminated')->once()->withNoArgs()->andReturn(true);
-        $this->process->shouldReceive('isSuccessful')->once()->withNoArgs()->andReturn(false);
-        $this->process->shouldReceive('getErrorOutput')->times(2)->withNoArgs()->andReturn($err);
-        $this->process->shouldReceive('getOutput')->times(2)->withNoArgs()->andReturn($out);
-        $this->process->shouldReceive('getCommandLine')->once()->withNoArgs()->andReturn('cli');
-        $this->process->shouldReceive('getExitCode')->once()->withNoArgs()->andReturn(123);
-        $this->process->shouldReceive('getExitCodeText')->once()->withNoArgs()->andReturn('baz');
+        $this->process->shouldReceive('isTerminated')->once()->andReturn(true);
+        $this->process->shouldReceive('isSuccessful')->once()->andReturn(false);
+        $this->process->shouldReceive('getErrorOutput')->times(2)->andReturn($err);
+        $this->process->shouldReceive('getOutput')->times(2)->andReturn($out);
+        $this->process->shouldReceive('getCommandLine')->once()->andReturn('cli');
+        $this->process->shouldReceive('getExitCode')->once()->andReturn(123);
+        $this->process->shouldReceive('getExitCodeText')->once()->andReturn('baz');
 
         $this->handler->shouldReceive('handleFail')
                       ->once()
@@ -90,7 +90,7 @@ class ProcessSupervisorTest extends TestCase
         $this->assertNull($this->sup->stdout);
 
         // Check wrapped process is the new one
-        $process->shouldReceive('isTerminated')->once()->withNoArgs()->andReturn(false);
+        $process->shouldReceive('isTerminated')->once()->andReturn(false);
         $this->sup->ping();
     }
 

--- a/tests/unit/SupervisorSupervisorTest.php
+++ b/tests/unit/SupervisorSupervisorTest.php
@@ -38,18 +38,20 @@ class SupervisorSupervisorTest extends TestCase
 
     public function testUnterminatedPing()
     {
-        $this->supA->shouldReceive('ping')->once()->withNoArgs()->andReturn(true);
-        $this->supB->shouldReceive('ping')->once()->withNoArgs()->andReturn(true);
-        $this->supC->shouldReceive('ping')->once()->withNoArgs()->andReturn(true);
+        $this->supA->shouldReceive('ping')->once()->andReturn(true);
+        $this->supB->shouldReceive('ping')->once()->andReturn(true);
+        $this->supC->shouldReceive('ping')->once()->andReturn(true);
+
+        $this->handler->shouldReceive('handleFail');
 
         $this->assertTrue($this->sup->ping());
     }
 
     public function testPartiallyTerminatedPing()
     {
-        $this->supA->shouldReceive('ping')->once()->withNoArgs()->andReturn(true);
-        $this->supB->shouldReceive('ping')->once()->withNoArgs()->andReturn(false);
-        $this->supC->shouldReceive('ping')->once()->withNoArgs()->andReturn(true);
+        $this->supA->shouldReceive('ping')->once()->andReturn(true);
+        $this->supB->shouldReceive('ping')->once()->andReturn(false);
+        $this->supC->shouldReceive('ping')->once()->andReturn(true);
 
         $this->handler->shouldReceive('handlePass')->once()->with(0, $this->sup);
 
@@ -60,9 +62,9 @@ class SupervisorSupervisorTest extends TestCase
     {
         $exception = new Exception('foo');
 
-        $this->supA->shouldReceive('ping')->once()->withNoArgs()->andReturn(true);
-        $this->supB->shouldReceive('ping')->once()->withNoArgs()->andReturn(true);
-        $this->supC->shouldReceive('ping')->once()->withNoArgs()->andThrow($exception);
+        $this->supA->shouldReceive('ping')->once()->andReturn(true);
+        $this->supB->shouldReceive('ping')->once()->andReturn(true);
+        $this->supC->shouldReceive('ping')->once()->andThrow($exception);
 
         $this->handler->shouldReceive('handleFail')->once()->with(0, $this->sup, $exception);
 
@@ -71,9 +73,9 @@ class SupervisorSupervisorTest extends TestCase
 
     public function testFullyTerminatedPing()
     {
-        $this->supA->shouldReceive('ping')->once()->withNoArgs()->andReturn(false);
-        $this->supB->shouldReceive('ping')->once()->withNoArgs()->andReturn(false);
-        $this->supC->shouldReceive('ping')->once()->withNoArgs()->andReturn(false);
+        $this->supA->shouldReceive('ping')->once()->andReturn(false);
+        $this->supB->shouldReceive('ping')->once()->andReturn(false);
+        $this->supC->shouldReceive('ping')->once()->andReturn(false);
 
         $this->handler->shouldReceive('handlePass')->times(3)->with(0, $this->sup);
 


### PR DESCRIPTION
With the version of mockery we are using, this ends up with a count(null)
check which is invalid in PHP 7.2. It results in this error message:

    count(): Parameter must be an array or an object that implements Countable

This is fixed in mockery 1.0, so the longer term fix would be to upgrade to
that.